### PR TITLE
Fix unwanted joins for inline tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,10 @@ How is html_text different from ``.xpath('//text()')`` from LXML
 or ``.get_text()`` from Beautiful Soup?
 Text extracted with ``html_text`` does not contain inline styles,
 javascript, comments and other text that is not normally visible to the users.
+It normalizes whitespace, but is also smarter than ``.xpath('normalize-space())``,
+adding spaces around inline elements too
+(which are often used as block elements in html markup),
+and tries to avoid adding extra spaces for punctuation.
 
 
 Install

--- a/html_text/html_text.py
+++ b/html_text/html_text.py
@@ -42,9 +42,9 @@ def parse_html(html):
 
 
 _whitespace = re.compile(r'\s+')
-_trailing_whitespace = re.compile(r'\s$')
-_punct_after = re.compile(r'^[,:;.!?"\)]')
-_punct_before = re.compile(r'\($')
+_has_trailing_whitespace = re.compile(r'\s$').search
+_has_punct_after = re.compile(r'^[,:;.!?"\)]').search
+_has_punct_before = re.compile(r'\($').search
 
 
 def selector_to_text(sel, guess_punct_space=False):
@@ -58,9 +58,9 @@ def selector_to_text(sel, guess_punct_space=False):
         def fragments():
             prev = None
             for text in sel.xpath('//text()').extract():
-                if prev is not None and (_trailing_whitespace.search(prev)
-                                         or (not _punct_after.search(text) and
-                                             not _punct_before.search(prev))):
+                if prev is not None and (_has_trailing_whitespace(prev)
+                                         or (not _has_punct_after(text) and
+                                             not _has_punct_before(prev))):
                     yield ' '
                 yield text
                 prev = text

--- a/html_text/html_text.py
+++ b/html_text/html_text.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import re
+
 import lxml
 import lxml.etree
 from lxml.html.clean import Cleaner
@@ -41,8 +43,13 @@ def parse_html(html):
 
 def selector_to_text(sel):
     """ Convert a cleaned selector to text.
+    Almost the same as xpath normalize-space, but this also
+    adds spaces between inline elements (like <span>) which are
+    often used as block elements in html markup.
     """
-    return sel.xpath('normalize-space()').extract_first('')
+    fragments = (re.sub('\s+', ' ', x.strip())
+                 for x in sel.xpath('//text()').extract())
+    return ' '.join(x for x in fragments if x)
 
 
 def cleaned_selector(html):

--- a/html_text/html_text.py
+++ b/html_text/html_text.py
@@ -47,11 +47,9 @@ _has_punct_after = re.compile(r'^[,:;.!?"\)]').search
 _has_punct_before = re.compile(r'\($').search
 
 
-def selector_to_text(sel, guess_punct_space=False):
+def selector_to_text(sel, guess_punct_space=True):
     """ Convert a cleaned selector to text.
-    Almost the same as xpath normalize-space, but this also
-    adds spaces between inline elements (like <span>) which are
-    often used as block elements in html markup.
+    See html_text.extract_text docstring for description of the approach and options.
     """
     if guess_punct_space:
 
@@ -87,9 +85,16 @@ def cleaned_selector(html):
     return sel
 
 
-def extract_text(html, guess_punct_space=False):
+def extract_text(html, guess_punct_space=True):
     """
     Convert html to text.
+    Almost the same as normalize-space xpath, but this also
+    adds spaces between inline elements (like <span>) which are
+    often used as block elements in html markup.
+
+    When guess_punct_space is True (default), no extra whitespace is added
+    for punctuation. This has a slight (around 10%) performance overhead
+    and is just a heuristic.
 
     html should be a unicode string or an already parsed lxml.html element.
     """

--- a/html_text/html_text.py
+++ b/html_text/html_text.py
@@ -68,9 +68,8 @@ def selector_to_text(sel, guess_punct_space=False):
         return _whitespace.sub(' ', ''.join(fragments()).strip())
 
     else:
-        fragments = (_whitespace.sub(' ', x.strip())
-                     for x in sel.xpath('//text()').extract())
-        return ' '.join(x for x in fragments if x)
+        fragments = (x.strip() for x in sel.xpath('//text()').extract())
+        return _whitespace.sub(' ', ' '.join(x for x in fragments if x))
 
 
 def cleaned_selector(html):

--- a/html_text/html_text.py
+++ b/html_text/html_text.py
@@ -41,13 +41,16 @@ def parse_html(html):
     return lxml.html.fromstring(html.encode('utf8'), parser=parser)
 
 
+_whitespace = re.compile('\s+')
+
+
 def selector_to_text(sel):
     """ Convert a cleaned selector to text.
     Almost the same as xpath normalize-space, but this also
     adds spaces between inline elements (like <span>) which are
     often used as block elements in html markup.
     """
-    fragments = (re.sub('\s+', ' ', x.strip())
+    fragments = (_whitespace.sub(' ', x.strip())
                  for x in sel.xpath('//text()').extract())
     return ' '.join(x for x in fragments if x)
 

--- a/html_text/html_text.py
+++ b/html_text/html_text.py
@@ -41,18 +41,36 @@ def parse_html(html):
     return lxml.html.fromstring(html.encode('utf8'), parser=parser)
 
 
-_whitespace = re.compile('\s+')
+_whitespace = re.compile(r'\s+')
+_trailing_whitespace = re.compile(r'\s$')
+_punct_after = re.compile(r'^[,:;.!?"\)]')
+_punct_before = re.compile(r'\($')
 
 
-def selector_to_text(sel):
+def selector_to_text(sel, guess_punct_space=False):
     """ Convert a cleaned selector to text.
     Almost the same as xpath normalize-space, but this also
     adds spaces between inline elements (like <span>) which are
     often used as block elements in html markup.
     """
-    fragments = (_whitespace.sub(' ', x.strip())
-                 for x in sel.xpath('//text()').extract())
-    return ' '.join(x for x in fragments if x)
+    if guess_punct_space:
+
+        def fragments():
+            prev = None
+            for text in sel.xpath('//text()').extract():
+                if prev is not None and (_trailing_whitespace.search(prev)
+                                         or (not _punct_after.search(text) and
+                                             not _punct_before.search(prev))):
+                    yield ' '
+                yield text
+                prev = text
+
+        return _whitespace.sub(' ', ''.join(fragments()).strip())
+
+    else:
+        fragments = (_whitespace.sub(' ', x.strip())
+                     for x in sel.xpath('//text()').extract())
+        return ' '.join(x for x in fragments if x)
 
 
 def cleaned_selector(html):
@@ -70,10 +88,11 @@ def cleaned_selector(html):
     return sel
 
 
-def extract_text(html, encoding='utf8'):
+def extract_text(html, guess_punct_space=False):
     """
     Convert html to text.
 
     html should be a unicode string or an already parsed lxml.html element.
     """
-    return selector_to_text(cleaned_selector(html))
+    sel = cleaned_selector(html)
+    return selector_to_text(sel, guess_punct_space=guess_punct_space)

--- a/tests/test_html_text.py
+++ b/tests/test_html_text.py
@@ -39,7 +39,7 @@ def test_inline_tags_whitespace(all_options):
 
 def test_punct_whitespace():
     html = u'<div><span>field</span>, and more</div>'
-    assert extract_text(html) == u'field , and more'
+    assert extract_text(html, guess_punct_space=False) == u'field , and more'
 
 
 def test_punct_whitespace_preserved():

--- a/tests/test_html_text.py
+++ b/tests/test_html_text.py
@@ -1,30 +1,49 @@
 # -*- coding: utf-8 -*-
+import pytest
 
 from html_text import extract_text, parse_html
 
 
-def test_extract_text():
+@pytest.fixture(params=[{'guess_punct_space': True},
+                        {'guess_punct_space': False}])
+def all_options(request):
+    return request.param
+
+
+def test_extract_text(all_options):
     html = u'<html><style>.div {}</style><body><p>Hello,   world!</body></html>'
-    assert extract_text(html) == u'Hello, world!'
+    assert extract_text(html, **all_options) == u'Hello, world!'
 
 
-def test_declared_encoding():
+def test_declared_encoding(all_options):
     html = (u'<?xml version="1.0" encoding="utf-8" ?>'
             u'<html><style>.div {}</style>'
             u'<body>Hello,   world!</p></body></html>')
-    assert extract_text(html) == u'Hello, world!'
+    assert extract_text(html, **all_options) == u'Hello, world!'
 
 
-def test_empty():
-    assert extract_text(u'') == ''
+def test_empty(all_options):
+    assert extract_text(u'', **all_options) == ''
 
 
-def test_extract_text_from_tree():
+def test_extract_text_from_tree(all_options):
     html = u'<html><style>.div {}</style><body><p>Hello,   world!</body></html>'
     tree = parse_html(html)
-    assert extract_text(tree) == u'Hello, world!'
+    assert extract_text(tree, **all_options) == u'Hello, world!'
 
 
-def test_inline_tags_whitespace():
-    html = u'<span>field</span><span>value</span>'
-    assert extract_text(html) == u'field value'
+def test_inline_tags_whitespace(all_options):
+    html = u'<span>field</span><span>value  of</span><span></span>'
+    assert extract_text(html, **all_options) == u'field value of'
+
+
+def test_punct_whitespace():
+    html = u'<div><span>field</span>, and more</div>'
+    assert extract_text(html) == u'field , and more'
+
+
+def test_punct_whitespace_preserved():
+    html = (u'<div><span>по</span><span>ле</span>, and  ,  '
+            u'<span>more </span>!<span>now</div>a (<b>boo</b>)')
+    assert (extract_text(html, guess_punct_space=True) ==
+            u'по ле, and , more ! now a (boo)')

--- a/tests/test_html_text.py
+++ b/tests/test_html_text.py
@@ -23,3 +23,8 @@ def test_extract_text_from_tree():
     html = u'<html><style>.div {}</style><body><p>Hello,   world!</body></html>'
     tree = parse_html(html)
     assert extract_text(tree) == u'Hello, world!'
+
+
+def test_inline_tags_whitespace():
+    html = u'<span>field</span><span>value</span>'
+    assert extract_text(html) == u'field value'


### PR DESCRIPTION
Fixes #1  - see examples by @codinguncut there. Inline tags are commonly used as block tags, and current ``normalize-space()`` results in unwanted joining of words - this branch fixes it by always adding whitespace between tags.

Checked old vs. new way on about 1000 html pages, on average the text is longer by 0.2% characters, with most pages having some difference. In all cases I checked (about 10 pages) the new way is better, unsplitting words that were joined without spaces, and I didn't find any unwanted splits.

The speed is almost 2x slower though: 7 s for 1000 html pages before, 11.5 s without regexp, 12.5 s with regexp (and caching). But I guess it's not that bad.

@codinguncut @kmike I would appreciate your review :) I have some vague memory that in some cases ``//text()`` is not what we want, but I can't recall in which and I didn't see anything bad in the tests I did.