### PR TITLE
Use .//text() to extract text from selector

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,16 @@ You can also pass already parsed ``lxml.html.HtmlElement``:
     >>> text = html_text.extract_text(tree)
     u'Hey'
 
+Passed html will be first cleaned from invisible non-text content such
+as styles, and then text would be extracted.
+Two functions that do it are ``html_text.cleaned_selector`` and
+``html_text.selector_to_text``:
+
+* ``html_text.cleaned_selector`` accepts html as text or as ``lxml.html.HtmlElement``,
+  and returns cleaned ``parsel.Selector``.
+* ``html_text.selector_to_text`` accepts ``parsel.Selector`` and returns extracted
+  text.
+
 
 Credits
 -------

--- a/html_text/__init__.py
+++ b/html_text/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-from .html_text import extract_text, parse_html
+from .html_text import extract_text, parse_html, cleaned_selector, selector_to_text

--- a/html_text/html_text.py
+++ b/html_text/html_text.py
@@ -55,7 +55,7 @@ def selector_to_text(sel, guess_punct_space=True):
 
         def fragments():
             prev = None
-            for text in sel.xpath('//text()').extract():
+            for text in sel.xpath('.//text()').extract():
                 if prev is not None and (_has_trailing_whitespace(prev)
                                          or (not _has_punct_after(text) and
                                              not _has_punct_before(prev))):
@@ -66,7 +66,7 @@ def selector_to_text(sel, guess_punct_space=True):
         return _whitespace.sub(' ', ''.join(fragments()).strip())
 
     else:
-        fragments = (x.strip() for x in sel.xpath('//text()').extract())
+        fragments = (x.strip() for x in sel.xpath('.//text()').extract())
         return _whitespace.sub(' ', ' '.join(x for x in fragments if x))
 
 
@@ -87,7 +87,7 @@ def cleaned_selector(html):
 
 def extract_text(html, guess_punct_space=True):
     """
-    Convert html to text.
+    Convert html to text, cleaning invisible content such as styles.
     Almost the same as normalize-space xpath, but this also
     adds spaces between inline elements (like <span>) which are
     often used as block elements in html markup.

--- a/tests/test_html_text.py
+++ b/tests/test_html_text.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from html_text import extract_text, parse_html
+from html_text import extract_text, parse_html, cleaned_selector, selector_to_text
 
 
 @pytest.fixture(params=[{'guess_punct_space': True},
@@ -47,3 +47,11 @@ def test_punct_whitespace_preserved():
             u'<span>more </span>!<span>now</div>a (<b>boo</b>)')
     assert (extract_text(html, guess_punct_space=True) ==
             u'по ле, and , more ! now a (boo)')
+
+
+def test_selector(all_options):
+    html = '<div><div id="extract-me">text<div>more</div></div>and more text</div>'
+    sel = cleaned_selector(html)
+    assert selector_to_text(sel, **all_options) == 'text more and more text'
+    subsel = sel.xpath('//div[@id="extract-me"]')[0]
+    assert selector_to_text(subsel, **all_options) == 'text more'


### PR DESCRIPTION
And expose functions that operate on selectors. Fixes #7