### PR TITLE
Support deploying to PyPI automatically from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,13 @@ after_success:
 cache:
     directories:
         - $HOME/.cache/pip
+
+deploy:
+    provider: pypi
+    user: "…"
+    password:
+        secure: "…"
+    distributions: "sdist bdist_wheel"
+    skip_existing: true
+    on:
+        tags: true


### PR DESCRIPTION
It only requires filling the `deploy.user` and `deploy.password.secure` fields as described in https://docs.travis-ci.com/user/deployment/pypi/